### PR TITLE
fix typos on I.1.3

### DIFF
--- a/Solution to Algebra, Chapter 0.tex
+++ b/Solution to Algebra, Chapter 0.tex
@@ -146,7 +146,7 @@ This work is licensed under a \href{http://creativecommons.org/licenses/by-nc-sa
 
 % Problem 1.3
 \begin{problem}[1.3]
-	$\vartriangleright$ Given a partition $\mathscr{P}$ on a set $S$, show how to define a
+	$\vartriangleright$ Given a partition $\mathscr{P}$ on a set $S$, show how to define an equivalence
 	relation $\sim$ such that $\mathscr{P} = \mathscr{P}_{\sim}$. [\S1.5]
 \end{problem}
 
@@ -165,7 +165,7 @@ This work is licensed under a \href{http://creativecommons.org/licenses/by-nc-sa
 		\mathscr{P}_{\sim}$, so $\mathscr{P}\subseteq\mathscr{P}_{\sim}$.
 		
 		\item ($\mathscr{P}_{\sim}\subseteq\mathscr{P}$). Let $[a]_{\sim}\in\mathscr{P}_{\sim}$.
-		From exercise I.1.1 we know that $[a]_{\sim}$ is non-empty. Suppose
+		From exercise I.1.2 we know that $[a]_{\sim}$ is non-empty. Suppose
 		$a'\in[a]_{\sim}$. By definition, since $a'\sim a$, there exists a set $X$ such
 		that $a,a'\in X$. Hence $[a]_{\sim}\subseteq X$. Also, if $a,a'\in X$ (not
 		necessarily distinct) then $a\sim a'$. Therefore,


### PR DESCRIPTION
Hi Hooy,

1) Errata: Although the omission of "equivalence" on page 8 of the book was confirmed (https://www.math.fsu.edu/~aluffi/algebraerrata.2009/Errata.html), the same problem persists in I.1.3.

2) srcreigh' typo: I.1.1 should've been I.1.2 instead.