### PR TITLE
Fix minor typos in chapter I

### DIFF
--- a/Solution to Algebra, Chapter 0.tex
+++ b/Solution to Algebra, Chapter 0.tex
@@ -664,7 +664,7 @@ and itself? [\textsection II.2.1]
 	\set{(A,B)}$ if $A\subseteq B$ and $\varnothing$ otherwise, for all sets
 	$A,B\in\mathscr{P}$. The category $\hat{S}$ is an instance of the categories
 	explained in Example 3.3 because $\subseteq$ is a reflexive and transitive
-	operation on the power set of any set $S$. Indeed, for $X,Y,Z\subseteq S$, we have
+	relation on the power set of any set $S$. Indeed, for $X,Y,Z\subseteq S$, we have
 	that $X\subseteq X$ and, if $X\subseteq Y$ and $Y\subseteq Z$, then if $x\in X$,
 	then $x\in Y$ and $x\in Z$ so $X\subseteq Z$.
 \end{solution}

--- a/Solution to Algebra, Chapter 0.tex
+++ b/Solution to Algebra, Chapter 0.tex
@@ -1297,7 +1297,7 @@ and itself? [\textsection II.2.1]
 	\end{tikzcd}\]
 	
 	\[\begin{tikzcd}[column sep=tiny]
-	\quotntws{(A\times B)}{\sim} \arrow[rr,"\quotuniv{\pi^B_{\sim_B}\circ\pi_B}"] && \quotntws{A}{\sim_A} \\
+	\quotntws{(A\times B)}{\sim} \arrow[rr,"\quotuniv{\pi^B_{\sim_B}\circ\pi_B}"] && \quotntws{B}{\sim_B} \\
 	&A\times B \arrow[ul,"\pi^{A\times B}_\sim"] \arrow[ur,swap, "\pi^B_{\sim_B}\circ\pi_B"]&
 	\end{tikzcd}\]
 	

--- a/Solution to Algebra, Chapter 0.tex
+++ b/Solution to Algebra, Chapter 0.tex
@@ -949,7 +949,7 @@ and itself? [\textsection II.2.1]
 		\mathrm{Hom}_\mathsf{C}(a, b)=
 		\left\{
 		\begin{aligned}
-		&(a, b)\in S\times S &\text{ if } a\sim b\\	
+		& \big\{ (a, b) \big\} \subset S\times S &\text{ if } a\sim b\\	
 		& \varnothing &\text{ otherwise}\\
 		\end{aligned}
 		\right.


### PR DESCRIPTION
Hello! I'm a beginner in abstract algebra, and your solutions are a great help for me to double-check my understanding of the text.

I still have a lot to learn before I can make substantial contributions, but here are several minor typos that I've spotted:

- In Exercise I.3.5, I think you mean a reflexive and transitive "relation" rather than "operation".
- In Exercise I.4.2, since Hom(a, b) is a set, curly brackets are needed.
- In Exercise I.5.11, the upper right object of the second commutative diagram should be `B/\sim_B` rather than `A/\sim_A`.