### PR TITLE
fix II.2.15 (the second bullet point)

### DIFF
--- a/Solution_to_Algebra_Chapter_0.tex
+++ b/Solution_to_Algebra_Chapter_0.tex
@@ -1671,7 +1671,7 @@ is an element of order $d$ in $S_n$.
 		which also implies $\gcd(2m+ n, n) = 1$.
 		\item If $\gcd(r, 2n) = 1$, then $r$ must be an odd integer and accordingly
 		\[
-		\gcd(2r-2n, 4n) = 1\implies a(2r-2n)+b(4n)=1\implies 4a \frac{r-n}{2}+4bn=1,
+		\gcd(r, n) = 1\implies ar+bn=1\implies 2a \left(\frac{r-n}{2}\right)+(a+b)n=1,
 		\]
 		which is $\gcd(\frac{r-n}{2}, n) = 1$.
 		\item It is easy to check that the function $f:(\mathbb{Z}/n\mathbb{Z})^*\rightarrow(\mathbb{Z}/2n\mathbb{Z})^*,\;[m]_n\mapsto[2m + n]_{2n}$ is well-defined. The fact


### PR DESCRIPTION
In the solution to exercise II.2.15, the claim that `gcd(2r-2n, 4n) = 1` is incorrect, since `2r-2n` and `4n` are both divisible by 2. This step should be changed to `gcd(r, n) = 1`, and the proof follows.