### PR TITLE
II.3.3: remove superfluous line in the proof that phi is a homomorphism

### DIFF
--- a/Solution_to_Algebra_Chapter_0.tex
+++ b/Solution_to_Algebra_Chapter_0.tex
@@ -1813,7 +1813,6 @@ is an element of order $d$ in $S_n$.
 	&=g(a_1+a_2)+h(b_1+b_2)\\
 	&=(g(a_1)+g(a_2))+(h(b_1)+h(b_2))\\
 	&=(g(a_1)+h(b_1))+(g(a_2)+h(b_2))\\
-	&=g(a_1+b_1)+h(a_2+b_2)\\
 	&=\varphi((a_1,b_1))+\varphi((a_2,b_2))
 	\end{aligned}
 	\]


### PR DESCRIPTION
In the solution to exercise II.3.3, a unique morphism `phi` satisfying the universal property is constructed. When checking that this is a valid morphism (i.e., it is a group homomorphism), there is a superfluous line saying

```
... = g(a_1+b_1)+h(a_2+b_2)
```

I believe this line should be removed, because it is an undefined operation to add an element `a_1` (or `a_2`) from group `G` and an element `b_1` (or `b_2`) from group `H`. Also, the proof is already coherent if you go from the previous line to the next line, using the definition of `phi`:

```
(g(a_1)+h(b_1)) + (g(a_2)+h(b_2))
= ((a_1,b_1)) + ((a_2,b_2))
```